### PR TITLE
Added missing semicolons

### DIFF
--- a/src/Gateway/Command/CollectorBankCommand.php
+++ b/src/Gateway/Command/CollectorBankCommand.php
@@ -276,7 +276,7 @@ class CollectorBankCommand implements CommandInterface
 
             throw new \Webbhuset\CollectorCheckout\Exception\Exception(
                 __($e->getMessage())
-            )
+            );
         }
 
         return true;
@@ -387,7 +387,7 @@ class CollectorBankCommand implements CommandInterface
             );
             throw new \Webbhuset\CollectorCheckout\Exception\Exception(
                 __($e->getMessage())
-            )
+            );
         }
 
         $this->transaction->create()->addTransaction(


### PR DESCRIPTION
This commit adds missing semicolons which when omitted cause the autoloader to break.