### PR TITLE
Updated CSP to also allow walleydev.com

### DIFF
--- a/src/etc/csp_whitelist.xml
+++ b/src/etc/csp_whitelist.xml
@@ -11,11 +11,18 @@
         <policy id="script-src">
             <values>
                 <value id="uat_collector" type="host">checkout-uat.collector.se</value>
+                <value id="uat_walley" type="host">checkout.uat.walleydev.com</value>
             </values>
         </policy>
         <policy id="frame-src">
             <values>
                 <value id="uat_collector" type="host">checkout-uat.collector.se</value>
+                <value id="uat_walley" type="host">checkout.uat.walleydev.com</value>
+            </values>
+        </policy>
+        <policy id="connect-src">
+            <values>
+                <value id="uat_walley" type="host">api.checkout.uat.walleydev.com</value>
             </values>
         </policy>
     </policies>


### PR DESCRIPTION
Updated the `script-src` and `frame-src` to accept `checkout.uat.walleydev.com`. Also added a `connect-src` to allow `api.checkout.uat.walleydev.com`.