### PR TITLE
Update success controller to use the full system config for the iframe

### DIFF
--- a/src/Controller/Success/Index.php
+++ b/src/Controller/Success/Index.php
@@ -97,7 +97,12 @@ class Index extends \Magento\Framework\App\Action\Action
         $publicToken = $orderDataHandler->getPublicToken($order);
 
         $iframeConfig = new \Webbhuset\CollectorCheckoutSDK\Config\IframeConfig(
-            $publicToken
+            $publicToken,
+            $this->config->getStyleDataLang(),
+            $this->config->getStyleDataPadding(),
+            $this->config->getStyleDataContainerId(),
+            $this->config->getStyleDataActionColor(),
+            $this->config->getStyleDataActionTextColor()
         );
         $iframe = \Webbhuset\CollectorCheckoutSDK\Iframe::getScript($iframeConfig, $this->config->getMode());
 


### PR DESCRIPTION
Fixes #64, or "fixes" might not be the correct word. But at least it allows the users of the module to define a container ID where the success iframe should be loaded. They will still need to add that container to the success page.