### PR TITLE
Add support for removing canceled orders on Validation-callback

### DIFF
--- a/src/Checkout/Order/Manager.php
+++ b/src/Checkout/Order/Manager.php
@@ -179,6 +179,9 @@ class Manager
             if (\Magento\Sales\Model\Order::STATE_NEW == $order->getState()) {
                 $this->removeAndCancelOrder($order);
             }
+            if (\Magento\Sales\Model\Order::STATE_CANCELED == $order->getState()) {
+                $this->deleteOrder($order);
+            }
         } catch (\Magento\Framework\Exception\NoSuchEntityException $e) {
         }
     }


### PR DESCRIPTION
If order have been canceled (by cron) we need to remove it if the same Checkout session is used for quote. We only want one order/Walley checkout.