### PR TITLE
#72 Invoice creation from API not working

### DIFF
--- a/src/Invoice/Transaction/Manager.php
+++ b/src/Invoice/Transaction/Manager.php
@@ -36,8 +36,8 @@ class Manager
      */
     public function addTransaction(
         \Magento\Sales\Api\Data\OrderInterface $order,
-	$type,
-	$status = false,
+	    $type,
+	    $status = false,
         $response = []
     ) {
         $payment = $order->getPayment();
@@ -73,7 +73,6 @@ class Manager
         if ($parentTransId) {
             $transaction->setParentTxnId($parentTransId);
         }
-        $transaction->save();
         $payment->save();
     }
 


### PR DESCRIPTION
Since Magento 2.4.4, Transaction\Builder auto-persists and auto-closes the parent AUTH on the first save. Our second manual save() created a self-parent loop, causing infinite recursion and PHP crashes; dropping that extra save fixes both Admin and API flows.