### PR TITLE
[WAL-20] Better Quote accessing in shipping collector

### DIFF
--- a/src/Carrier/Collector.php
+++ b/src/Carrier/Collector.php
@@ -2,6 +2,8 @@
 
 namespace Webbhuset\CollectorCheckout\Carrier;
 
+use Magento\Quote\Api\Data\CartInterface;
+
 /**
  * Class Collector
  *
@@ -31,10 +33,6 @@ class Collector extends \Magento\Shipping\Model\Carrier\AbstractCarrierOnline im
      * @var \Magento\Quote\Model\Quote\Address\RateResult\MethodFactory
      */
     protected $rateResultMethodFactory;
-    /**
-     * @var \Magento\Quote\Api\CartRepositoryInterface
-     */
-    protected $quoteRepository;
 
     private \Webbhuset\CollectorCheckout\Shipment\DeliveryCheckoutData $deliveryCheckoutData;
 
@@ -76,13 +74,11 @@ class Collector extends \Magento\Shipping\Model\Carrier\AbstractCarrierOnline im
         \Magento\Directory\Helper\Data $directoryData,
         \Magento\CatalogInventory\Api\StockRegistryInterface $stockRegistry,
         \Webbhuset\CollectorCheckout\Data\QuoteHandler $quoteDataHandler,
-        \Magento\Quote\Api\CartRepositoryInterface $quoteRepository,
         array $data = []
     ) {
         $this->rateResultFactory        = $rateResultFactory;
         $this->rateResultMethodFactory  = $rateResultMethodFactory;
         $this->quoteDataHandler         = $quoteDataHandler;
-        $this->quoteRepository          = $quoteRepository;
 
         parent::__construct(
             $scopeConfig,
@@ -132,16 +128,15 @@ class Collector extends \Magento\Shipping\Model\Carrier\AbstractCarrierOnline im
     /**
      * Get shipping method based on a quote and the information in collector checkout data
      *
-     * @param int $quoteId
+     * @param CartInterface $quote
      * @return array|\Magento\Quote\Model\Quote\Address\RateResult\Method
      * @throws \Magento\Framework\Exception\NoSuchEntityException
      */
-    public function getMethodForQuote(int $quoteId)
+    public function getMethodForQuote(CartInterface $quote)
     {
         if ($this->deliveryCheckoutData->getData()) {
             $shippingData = $this->deliveryCheckoutData->getData();
         } else {
-            $quote = $this->quoteRepository->get($quoteId);
             $shippingData = $this->quoteDataHandler->getDeliveryCheckoutData($quote);
         }
 
@@ -177,14 +172,14 @@ class Collector extends \Magento\Shipping\Model\Carrier\AbstractCarrierOnline im
             return $result;
         }
 
-        /** @var \Magento\Quote\Model\Quote\Item\Interceptor $quote */
-        $quote = $quoteItems[0];
-        $quoteId = $quote->getQuoteId();
-        if (!$quoteId) {
+        /** @var \Magento\Quote\Model\Quote\Item $quoteItem */
+        $quoteItem = $quoteItems[0];
+        $quote = $quoteItem->getQuote();
+        if (!$quote || !$quote->getId()) {
             return $result;
         }
 
-        $method = $this->getMethodForQuote($quoteId);
+        $method = $this->getMethodForQuote($quote);
         if (!empty($method)) {
             $result->append($method);
         }


### PR DESCRIPTION
Remove use of quote repository loading in shipping method collector, because repository loading can trigger totals collection and thus an infinite loop