### PR TITLE
[WAL-23] Fix invoice registration issue

### DIFF
--- a/src/Invoice/RowMatcher/InvoiceHandler.php
+++ b/src/Invoice/RowMatcher/InvoiceHandler.php
@@ -102,6 +102,5 @@ class InvoiceHandler
         \Magento\Sales\Api\Data\OrderInterface $order
     ):void {
         $this->orderHandler->setDecimalRoundingInvoiced($order);
-        $this->orderRepository->save($order);
     }
 }


### PR DESCRIPTION
Removed extra order save that happened during invoice capture, which would set items and order amounts as invoiced even if capture failed and invoice not saved.

The extra order save is not necessary as everything is saved after capture process anyway.