### PR TITLE
feat: whitelist production and missing UAT checkout domains in CSP

### DIFF
--- a/src/etc/csp_whitelist.xml
+++ b/src/etc/csp_whitelist.xml
@@ -12,17 +12,29 @@
             <values>
                 <value id="uat_collector" type="host">checkout-uat.collector.se</value>
                 <value id="uat_walley" type="host">checkout.uat.walleydev.com</value>
+                <value id="prod_collector" type="host">checkout.collector.se</value>
+                <value id="prod_walley" type="host">checkout.walley.se</value>
             </values>
         </policy>
         <policy id="frame-src">
             <values>
                 <value id="uat_collector" type="host">checkout-uat.collector.se</value>
                 <value id="uat_walley" type="host">checkout.uat.walleydev.com</value>
+                <value id="prod_collector" type="host">checkout.collector.se</value>
+                <value id="prod_walley" type="host">checkout.walley.se</value>
             </values>
         </policy>
         <policy id="connect-src">
             <values>
                 <value id="uat_walley" type="host">api.checkout.uat.walleydev.com</value>
+                <value id="api_walleypay" type="host">api.walleypay.com</value>
+                <value id="api_checkout_walleypay" type="host">api.checkout.walleypay.com</value>
+                <value id="api_checkout_walley" type="host">api.checkout.walley.se</value>
+                <value id="api_checkout_collector" type="host">api.checkout.collector.se</value>
+                <value id="checkout_collector" type="host">checkout.collector.se</value>
+                <value id="checkout_walley" type="host">checkout.walley.se</value>
+                <value id="checkout_uat_collector" type="host">checkout-uat.collector.se</value>
+                <value id="checkout_uat_walley" type="host">checkout.uat.walleydev.com</value>
             </values>
         </policy>
     </policies>


### PR DESCRIPTION
This PR updates the module's CSP configuration to whitelist the official production and UAT domains for Walley/Collector checkout. This prevents the browser from blocking checkout scripts, payment frames, and API requests when Magento is running in CSP `restrictive` mode.

**Problem**
In default Magento 2.4.7+ / 2.4.8+ configurations or installations where the Content Security Policy is set to `restrictive` mode, the checkout page will fail to load or interact with Walley. The browser blocks the external resources and network requests because they aren't whitelisted.

The module's original `csp_whitelist.xml` only whitelisted a few UAT domains and completely lacked the production domains (QA?). Yes, I missed it as well in https://github.com/collector-bank/Checkout-Magento-2/pull/63, blaming it on a site not in `restrictive` mode.

**Fix**
This PR updates `csp_whitelist.xml` to include all required subdomains and endpoints for both UAT and Production environments across three client-side policies.

**Verified domains**

| Policy | Domain | Environment | Purpose |
| :--- | :--- | :--- | :--- |
| **`script-src`** / **`frame-src`** | `checkout.walley.se`<br>`checkout.collector.se` | Production | Checkout loader script and payment iframe |
| **`script-src`** / **`frame-src`** | `checkout.uat.walleydev.com`<br>`checkout-uat.collector.se` | UAT | Checkout loader script and payment iframe (Test) |
| **`connect-src`** | `api.walleypay.com`<br>`api.checkout.walleypay.com` | Production | Core checkout API gateways |
| **`connect-src`** | `api.checkout.walley.se`<br>`api.checkout.collector.se` | Production | Nordic/Sweden region API endpoints |
| **`connect-src`** | `api.checkout.uat.walleydev.com` | UAT | Test API gateway |